### PR TITLE
Fixing buildpack so that it runs

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+echo "MaxMind GeoIP Free Database Installer"
 exit 0 # should always run


### PR DESCRIPTION
This buildpack failed to build on Heroku, producing 'Failed to detect set buildpack' errors.

I found that a patch needed to be applied, exactly as [this PR](https://github.com/mantisadnetwork/heroku-buildpack-maxmind/pull/2) on the heroku-buildpack-maxmind repo.

Cheers and thanks for the great buildpack!