### PR TITLE
Use Maxmind license key when downloading databases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The database file(s) is saved to a Heroku cache directory that is persisted acro
 
 ## Required Environment Variables
 * MAXMIND_EDITIONS = Comma delimited list of databases to download ie: "GeoLite2-City,GeoLite2-Country"
+* MAXMIND_KEY = License key necessary to download MaxMind GeoLite2 databases.
 
 ## How to Use
 Follow the instructions at https://github.com/ddollar/heroku-buildpack-multi for using multiple build packs. Simply add this repository to this list and wallah!

--- a/bin/compile
+++ b/bin/compile
@@ -7,6 +7,7 @@ CACHE_DIR=$2
 ENV_DIR=$3
 
 MAXMIND_EDITIONS=`cat $ENV_DIR/MAXMIND_EDITIONS`
+MAXMIND_KEY=`cat $ENV_DIR/MAXMIND_KEY`
 
 mkdir -p $CACHE_DIR
 
@@ -37,7 +38,7 @@ download(){
 		if [ ! -f $FILE ]; then
 			echo "-----> $EDITION: Database does not exist in cache, downloading."
 
-			curl -o $FILE -L "http://geolite.maxmind.com/download/geoip/database/${EDITION}.mmdb.gz"
+			curl -o $FILE -L "https://download.maxmind.com/app/geoip_download?edition_id=${EDITION}&license_key=${MAXMIND_KEY}&suffix=tar.gz"
 		fi
 
 		echo "-----> $EDITION: Extracting $FILE"


### PR DESCRIPTION
Maxmind now requires users of Geolite2 databases to have a license key.

https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/